### PR TITLE
Make tenant-specific template loading work.

### DIFF
--- a/django_tenant_templates/middleware.py
+++ b/django_tenant_templates/middleware.py
@@ -12,7 +12,8 @@ class TenantMiddleware(object):
         local.tenant_slug = getattr(request, self.slug_property_name, None)
 
     def process_exception(self, request, exception):
-        try:
-            del local.tenant_slug
-        except AttributeError:
-            pass
+        """ Used to disable tenant-specific template loading on errors. 
+        Now has no special behavior as it is desirable to have tenant-specific
+        error handling pages.
+        """
+        pass


### PR DESCRIPTION
Makes custom error "Sorry" pages work.

We recently wrote custom 500 and 404 error-handling templates for our project containing different support contact information for our various tenants.  We ran into the problem that unlike the other areas of our project, the error handling view was not rendering the correct template based on our tenant.  It was always displaying the base template.

We traced the problem to the middleware of this library.  It looks like if there is an error, then `process_exception()` deletes the tenant_slug variable.

The loader.py file in this library only returns a tenant-specific template path if `not template_name.startswith('./') and hasattr(local, 'tenant_slug') and local.tenant_slug is not None`.  Since `hasattr(local, 'tenant_slug')` is False. we cannot get a tenant-specific template path.

This behavior seems very intentional as the code is concise and cleanly written and very specifically delete the tenant_slug attribute.  So my question is: if so, then why?  What's undesirable about having tenant-specific error-handling templates?

p.s.  Hi Joe :wave:  :smiley_cat: 
